### PR TITLE
Export graphs in a single PDF file

### DIFF
--- a/source/controller/controller.py
+++ b/source/controller/controller.py
@@ -9,11 +9,13 @@ from source.controller.project_controller import ProjectController
 from source.controller.welcome_controller import WelcomeController
 from source.controller.wizard_controller import WizardController
 from source.domain import utils_file
-from source.domain.exports import export_g6_to_png, export_g6_to_tikz, export_g6_to_pdf, export_g6_to_sheet
+from source.domain.exports import export_g6_to_png, export_g6_to_tikz, export_g6_to_pdf, export_g6_to_sheet, \
+    export_g6_list_to_pdf
 from source.domain.utils import trigger_message_box, handle_invalid_export_format
 from source.domain.utils_file import import_gml_graph, create_gml_file
 from source.store.project_information_store import project_information_store
 from source.store.project_information_store import update_project_store
+from source.view.components.dialog import Dialog
 from source.view.loading.loading_window import LoadingWindow
 
 
@@ -48,6 +50,7 @@ class Controller:
         self.project_controller.tree_file_dock.export_g6_action.triggered.connect(self.export_to_g6)
         self.project_controller.tree_file_dock.export_tikz_action.triggered.connect(self.export_to_tikz)
         self.project_controller.tree_file_dock.export_pdf_action.triggered.connect(self.export_to_pdf)
+        self.project_controller.tree_file_dock.export_single_pdf_action.triggered.connect(self.export_to_single_pdf)
         self.project_controller.tree_file_dock.export_sheet_action.triggered.connect(self.export_to_sheet)
 
     def connect_events(self):
@@ -246,6 +249,25 @@ class Controller:
                     pass
                 self.update_loading_window(step)
             self.loading_window.close()
+
+    def export_to_single_pdf(self):
+        info_window = Dialog()
+        if info_window.exec_() == QDialog.Accepted:
+            try:
+                graph_to_export = self.get_graph_from_tree()
+            except:
+                return
+
+            if graph_to_export is None:
+                handle_invalid_export_format()
+                return
+
+            file_dir = utils_file.get_directory_name_from_existing_directory()
+            if file_dir:
+                self.show_loading_window(len(graph_to_export))
+                export_g6_list_to_pdf(graph_to_export, file_dir, info_window.get_number_rows(),
+                                      info_window.get_number_cols(), self.loading_window, self.update_loading_window)
+                self.loading_window.close()
 
     def export_to_g6(self):
         try:

--- a/source/controller/controller.py
+++ b/source/controller/controller.py
@@ -262,10 +262,10 @@ class Controller:
                 handle_invalid_export_format()
                 return
 
-            file_dir = utils_file.get_directory_name_from_existing_directory()
-            if file_dir:
+            file_name = utils_file.get_name_from_save_dialog('pdf')
+            if file_name:
                 self.show_loading_window(len(graph_to_export))
-                export_g6_list_to_pdf(graph_to_export, file_dir, info_window.get_number_rows(),
+                export_g6_list_to_pdf(graph_to_export, file_name, info_window.get_number_rows(),
                                       info_window.get_number_cols(), self.loading_window, self.update_loading_window)
                 self.loading_window.close()
 

--- a/source/domain/exports.py
+++ b/source/domain/exports.py
@@ -1,11 +1,13 @@
 import math
 import os
+from typing import Callable
 
 import matplotlib.pyplot as plt
 
 import networkx as nx
 import xlsxwriter
 import network2tikz as nxtikz
+from networkx import NetworkXError
 
 from source.domain.utils import convert_g6_to_nx
 from source.store.operations_invariants import dic_invariants_to_visualize as dic
@@ -36,40 +38,55 @@ def export_g6_to_pdf(g6code, folder, count):
     plt.close()
 
 
-def export_g6_list_to_pdf(g6codes, file_path, number_rows, number_cols, loading_window, update_loading):
-    num_graphs = len(g6codes)
-    graphs_per_page = number_rows * number_cols
-    num_pages = math.ceil(num_graphs / graphs_per_page)
+def draw_graph(graph, ax, idx, node_size, font_size):
+    nx.draw_networkx(graph, ax=ax, node_color='white', edgecolors='black',
+                     labels={node: node for node in nx.nodes(graph)}, node_size=node_size,
+                     font_size=font_size)
+    ax.set_title(f"Graph {idx + 1}", fontsize=font_size)
+
+
+def plot_graphs_on_page(g6_graphs, start_index, end_index, number_rows, number_cols, node_size, font_size,
+                        last_page=False):
+    fig, axs = plt.subplots(number_rows, number_cols, figsize=(8.27, 11.69), tight_layout=True)
+    for i, idx in enumerate(range(start_index, end_index)):
+        row, col = divmod(i, number_cols)
+        ax = axs[row, col] if number_rows > 1 else axs[col] if number_cols > 1 else axs
+        try:
+            graph = nx.from_graph6_bytes(g6_graphs[idx].encode('utf-8'))
+            draw_graph(graph, ax, idx, node_size, font_size)
+        except NetworkXError:
+            i -= 1
+
+    if last_page:
+        for j in range(i + 1, number_rows * number_cols):
+            fig.delaxes(axs.flatten()[j])
+
+    return fig
+
+
+def export_g6_list_to_pdf(g6_graphs: list[str], file_path: str, number_rows: int, number_cols: int,
+                          loading_window: object, update_loading: Callable):
+    number_graphs = len(g6_graphs)
+    elements_per_page = number_rows * number_cols
+    number_pages = math.ceil(number_graphs / elements_per_page)
+    max_dimension = max(number_rows, number_cols)
+    node_size = 500 / max_dimension
+    font_size = 18 / (max_dimension ** (1 / 1.618))
 
     with PdfPages(file_path) as pdf:
-        for page in range(num_pages):
-            start_idx = page * graphs_per_page
-            end_idx = min((page + 1) * graphs_per_page, num_graphs)
-            remaining_graphs = end_idx - start_idx
-            rows = min(remaining_graphs, number_rows)
-
-            fig, axs = plt.subplots(rows, number_cols, figsize=(8.27, 11.69), tight_layout=True)
-
-            for i, idx in enumerate(range(start_idx, end_idx)):
-                row = i // number_cols
-                col = i % number_cols
-
-                graph = nx.from_graph6_bytes(g6codes[idx].encode('utf-8'))
-                ax = axs[row, col] if rows > 1 else axs[col]
-                nx.draw_networkx(graph, ax=ax, node_color='#EEF25C', labels={item: item for item in nx.nodes(graph)})
-                ax.set_title(f"Graph {idx + 1}")
-
-                if loading_window.is_forced_to_close:
-                    loading_window.is_forced_to_close = False
-                    return
-
-                update_loading(idx)
-
-            for j in range(i + 1, number_rows * number_cols):
-                fig.delaxes(axs.flatten()[j])
-
+        for page in range(number_pages):
+            start_index = page * elements_per_page
+            end_index = min((page + 1) * elements_per_page, number_graphs)
+            last_page = page == number_pages - 1
+            fig = plot_graphs_on_page(g6_graphs, start_index, end_index, number_rows, number_cols, node_size, font_size,
+                                      last_page)
             pdf.savefig(fig)
-            plt.close()
+            plt.close(fig)
+
+            if loading_window.is_forced_to_close:
+                loading_window.is_forced_to_close = False
+                return
+            update_loading(end_index - 1)
 
 
 def export_g6_to_sheet(graph_list, invariants, file_name, update_progress, loading_window):

--- a/source/domain/exports.py
+++ b/source/domain/exports.py
@@ -36,13 +36,12 @@ def export_g6_to_pdf(g6code, folder, count):
     plt.close()
 
 
-def export_g6_list_to_pdf(g6codes, folder, number_rows, number_cols, loading_window, update_loading):
+def export_g6_list_to_pdf(g6codes, file_path, number_rows, number_cols, loading_window, update_loading):
     num_graphs = len(g6codes)
     graphs_per_page = number_rows * number_cols
     num_pages = math.ceil(num_graphs / graphs_per_page)
-    pdf_path = f"{folder}/Graphs.pdf"
 
-    with PdfPages(pdf_path) as pdf:
+    with PdfPages(file_path) as pdf:
         for page in range(num_pages):
             start_idx = page * graphs_per_page
             end_idx = min((page + 1) * graphs_per_page, num_graphs)
@@ -65,6 +64,9 @@ def export_g6_list_to_pdf(g6codes, folder, number_rows, number_cols, loading_win
                     return
 
                 update_loading(idx)
+
+            for j in range(i + 1, number_rows * number_cols):
+                fig.delaxes(axs.flatten()[j])
 
             pdf.savefig(fig)
             plt.close()

--- a/source/view/components/dialog.py
+++ b/source/view/components/dialog.py
@@ -1,0 +1,29 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
+
+
+class Dialog(QDialog):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Graph Configuration")
+        self.layout = QVBoxLayout(self)
+        self.label_rows = QLabel("Enter number of rows:")
+        self.input_field_rows = QLineEdit()
+        self.label_cols = QLabel("Enter number of columns:")
+        self.input_field_cols = QLineEdit()
+        self.button = QPushButton("OK")
+        self.set_up_layout()
+        self.button.clicked.connect(self.accept)
+
+    def set_up_layout(self):
+        self.layout.addWidget(self.label_rows)
+        self.layout.addWidget(self.input_field_rows)
+        self.layout.addWidget(self.label_cols)
+        self.layout.addWidget(self.input_field_cols)
+        self.layout.addWidget(self.button)
+        self.setLayout(self.layout)
+
+    def get_number_rows(self):
+        return int(self.input_field_rows.text())
+
+    def get_number_cols(self):
+        return int(self.input_field_cols.text())

--- a/source/view/components/dialog.py
+++ b/source/view/components/dialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QLabel, QLineEdit, QPushButton, QMessageBox
 
 
 class Dialog(QDialog):
@@ -12,7 +12,10 @@ class Dialog(QDialog):
         self.input_field_cols = QLineEdit()
         self.button = QPushButton("OK")
         self.set_up_layout()
+
         self.button.clicked.connect(self.accept)
+        self.input_field_rows.textEdited.connect(self.validate_input)
+        self.input_field_cols.textEdited.connect(self.validate_input)
 
     def set_up_layout(self):
         self.layout.addWidget(self.label_rows)
@@ -21,6 +24,17 @@ class Dialog(QDialog):
         self.layout.addWidget(self.input_field_cols)
         self.layout.addWidget(self.button)
         self.setLayout(self.layout)
+
+    def validate_input(self):
+        sender = self.sender()
+        text = sender.text()
+        try:
+            value = int(text)
+            if value <= 0:
+                raise ValueError
+        except ValueError:
+            QMessageBox.warning(self, "Invalid input", "The value must be an integer greater than 0")
+            sender.clear()
 
     def get_number_rows(self):
         return int(self.input_field_rows.text())

--- a/source/view/project/docks/tree_file_dock.py
+++ b/source/view/project/docks/tree_file_dock.py
@@ -19,6 +19,7 @@ class TreeFileDock(QDockWidget):
 
         self.export_png_action = QAction("Image (.png)")
         self.export_pdf_action = QAction("Image (.pdf)")
+        self.export_single_pdf_action = QAction("Single image (.pdf)")
         self.export_tikz_action = QAction("LaTeX Tikz (.tex)")
         self.export_g6_action = QAction("graph6 list (.txt)")
         self.export_sheet_action = QAction("Sheet (.xlsx): graph6 and invariants")
@@ -55,4 +56,5 @@ class TreeFileDock(QDockWidget):
         prev_menu_export.addAction(self.export_tikz_action)
         prev_menu_export.addAction(self.export_g6_action)
         prev_menu_export.addAction(self.export_pdf_action)
+        prev_menu_export.addAction(self.export_single_pdf_action)
         prev_menu_export.addAction(self.export_sheet_action)

--- a/source/view/project/docks/visualize_graph_dock.py
+++ b/source/view/project/docks/visualize_graph_dock.py
@@ -136,5 +136,5 @@ class ResizableGraph(EditableGraph):
             artist = self.ax.text(x + dx, y + dy, label, **node_label_fontdict)
 
             if node in self.node_label_artists:
-                self.node_label_artists[node].remove()
+                self.node_label_artists[node].remove()  
             self.node_label_artists[node] = artist

--- a/source/view/wizard/pages/method_page.py
+++ b/source/view/wizard/pages/method_page.py
@@ -17,13 +17,12 @@ class MethodPage(QWizardPage):
 
         self.filter_button = QPushButton()
         self.find_example_button = QPushButton()
-        self.blank_project =QPushButton()
+        self.blank_project = QPushButton()
 
         self.set_content_attributes()
         self.set_up_layout()
 
     def set_content_attributes(self):
-
         self.filter_button.setText("  Filter Graphs")
         self.filter_button.setIcon(Icon("filter"))
         self.filter_button.setMinimumHeight(50)
@@ -40,7 +39,7 @@ class MethodPage(QWizardPage):
 
         self.blank_project.setText(" Blank project \n "
                                    "Draw your own graphs")
-        
+
         self.blank_project.setIcon(Icon("edit"))
         self.blank_project.setMinimumHeight(50)
         self.blank_project.setMinimumWidth(100)
@@ -54,12 +53,11 @@ class MethodPage(QWizardPage):
         button_layout.addWidget(self.filter_button)
         button_layout.addWidget(self.find_example_button)
 
-
         second_button_layout = QHBoxLayout()
         second_button_layout.addWidget(self.blank_project)
-        #second_button_layout.setAlignment(Qt.AlignCenter)
-        second_button_layout.setContentsMargins(150,0,150,0)
-        #second_button_layout.
+        # second_button_layout.setAlignment(Qt.AlignCenter)
+        second_button_layout.setContentsMargins(150, 0, 150, 0)
+        # second_button_layout.
 
         layout = QVBoxLayout()
         layout.addStretch(3)


### PR DESCRIPTION
The issue #430 will be addressed in this branch. Its solution should also include the following functionality: 

- In the export submenu of the tree's context menu there will be a function to export a list of graphs (.g6 or .txt) in a single PDF.
- When selected, a dialog box will open asking the user for the number of graphs to be exported and the number of graphs to be displayed on each line of the file.
- Next, a new window will be used to select the file name and save location (as already done in the other exports).
- Pay attention to input validation.

Closes #430 

