### PR TITLE
Implement `Gem-Free` invariant

### DIFF
--- a/source/store/operations_and_invariants/bool_invariants.py
+++ b/source/store/operations_and_invariants/bool_invariants.py
@@ -815,3 +815,22 @@ class InvertibleMatrixR(InvariantBool):
     @staticmethod
     def print(graph, precision):
         return Utils.print_boolean(InvertibleMatrixR.calculate(graph), precision)
+
+
+class GemFree(InvariantBool):
+    name = "Gem-free"
+    type = 'bool_structural'
+
+    @staticmethod
+    def calculate(graph):
+        for node in graph.nodes():
+            neighbors = set(graph.neighbors(node))
+            for neighbor1 in neighbors:
+                for neighbor2 in neighbors:
+                    if neighbor1 != neighbor2 and graph.has_edge(neighbor1, neighbor2):
+                        return False
+        return True
+
+    @staticmethod
+    def print(graph, precision):
+        return Utils.print_boolean(GemFree.calculate(graph), precision)

--- a/source/store/operations_and_invariants/bool_invariants.py
+++ b/source/store/operations_and_invariants/bool_invariants.py
@@ -1,3 +1,5 @@
+import itertools
+
 import grinpy as gp
 import networkx as nx
 import networkx.algorithms.threshold
@@ -823,12 +825,14 @@ class GemFree(InvariantBool):
 
     @staticmethod
     def calculate(graph):
-        for node in graph.nodes():
-            neighbors = set(graph.neighbors(node))
-            for neighbor1 in neighbors:
-                for neighbor2 in neighbors:
-                    if neighbor1 != neighbor2 and graph.has_edge(neighbor1, neighbor2):
-                        return False
+        gem_graph = nx.Graph()
+        gem_graph.add_nodes_from(range(5))
+        gem_graph.add_edges_from([(0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (2, 3), (3, 4)])
+
+        for node_subset in set(itertools.combinations(graph.nodes(), 5)):
+            subgraph = graph.subgraph(list(node_subset))
+            if nx.is_isomorphic(subgraph, gem_graph):
+                return False
         return True
 
     @staticmethod


### PR DESCRIPTION
Closes #456

> [!Note]
> In the [grinpy ](https://pypi.org/project/grinpy/)library, for `free` invariants such as `Bull-Free`, which we already have, there is already a ready-made implementation for checking this condition. However, in the case of `Gem-Free`, we had to create our own implementation, following the model adopted by _**grinpy**_. Here is an example of a method from the library:

```python
def is_bull_free(G):
    # define a bull graph, also known as the graph obtained from the complete graph K_3 by addiing two pendants
    bull = gp.Graph([(0, 1), (0, 2), (1, 2), (1, 3), (2, 4)])

    # enumerate over all possible combinations of 5 vertices contained in G
    for S in set(itertools.combinations(G.nodes(), 5)):
        H = G.subgraph(list(S))
        if gp.is_isomorphic(H, bull):
            return False
    # if the above loop completes, the graph is bull-free
    return True
```
The same logic was followed, replacing the `bull_graph` with a `gem_graph`