### PR TITLE
Implement `Dart-Free` invariant

### DIFF
--- a/source/store/operations_and_invariants/bool_invariants.py
+++ b/source/store/operations_and_invariants/bool_invariants.py
@@ -1,3 +1,5 @@
+import itertools
+
 import grinpy as gp
 import networkx as nx
 import networkx.algorithms.threshold
@@ -815,3 +817,25 @@ class InvertibleMatrixR(InvariantBool):
     @staticmethod
     def print(graph, precision):
         return Utils.print_boolean(InvertibleMatrixR.calculate(graph), precision)
+
+
+class DartFree(InvariantBool):
+    name = "Dart-free"
+    type = 'bool_structural'
+
+    @staticmethod
+    def calculate(graph):
+        dart_graph = nx.complete_graph(4)
+        dart_graph.remove_edge(0, 1)
+        new_node = max(dart_graph.nodes()) + 1
+        dart_graph.add_edge(new_node, 0)
+
+        for node_subset in set(itertools.combinations(graph.nodes(), 5)):
+            subgraph = graph.subgraph(list(node_subset))
+            if nx.is_isomorphic(subgraph, dart_graph):
+                return False
+        return True
+
+    @staticmethod
+    def print(graph, precision):
+        return Utils.print_boolean(DartFree.calculate(graph), precision)

--- a/source/store/operations_and_invariants/bool_invariants.py
+++ b/source/store/operations_and_invariants/bool_invariants.py
@@ -828,7 +828,7 @@ class DartFree(InvariantBool):
         dart_graph = nx.complete_graph(4)
         dart_graph.remove_edge(0, 1)
         new_node = max(dart_graph.nodes()) + 1
-        dart_graph.add_edge(new_node, 0)
+        dart_graph.add_edge(new_node, 2)
 
         for node_subset in set(itertools.combinations(graph.nodes(), 5)):
             subgraph = graph.subgraph(list(node_subset))


### PR DESCRIPTION
Closes #455 

> [!Note]
> In the [grinpy ](https://pypi.org/project/grinpy/)library, for `free` invariants such as `Bull-Free`, which we already have, there is already a ready-made implementation for checking this condition. However, in the case of `Dart-Free`, we had to create our own implementation, following the model adopted by _**grinpy**_. Here is an example of a method from the library:

```python
def is_bull_free(G):
    # define a bull graph, also known as the graph obtained from the complete graph K_3 by addiing two pendants
    bull = gp.Graph([(0, 1), (0, 2), (1, 2), (1, 3), (2, 4)])

    # enumerate over all possible combinations of 5 vertices contained in G
    for S in set(itertools.combinations(G.nodes(), 5)):
        H = G.subgraph(list(S))
        if gp.is_isomorphic(H, bull):
            return False
    # if the above loop completes, the graph is bull-free
    return True
```
The same logic was followed, replacing the `bull_graph` with a `dart_graph`